### PR TITLE
adding dynamic and additive noise to realization

### DIFF
--- a/model/example.py
+++ b/model/example.py
@@ -22,6 +22,14 @@ times, signal = model.make_realization()
 plt.plot(times, signal)
 plt.show()
 
+# Adding noise to the signal
+
+model = pm.PointModel(gamma=0.1, total_duration=100, dt=0.01)
+model.add_noise(noise_to_signal_ratio=0.01, noise_type="additive", seed=None)
+times, signal = model.make_realization()
+
+plt.plot(times, signal)
+plt.show()
 
 # Say you want to customise your model a bit: use constant amplitude distribution, and box pulse shapes
 

--- a/model/point_model.py
+++ b/model/point_model.py
@@ -13,6 +13,8 @@ from model.pulse_shape import (
     ExponentialShortPulseGenerator,
     PulseGenerator,
 )
+from scipy.signal import fftconvolve
+
 
 __COMMON_DISTRIBUTIONS__ = ["exp", "deg"]
 
@@ -44,6 +46,7 @@ class PointModel:
         self._forcing_generator: ForcingGenerator = StandardForcingGenerator()
         self._pulse_generator: ShortPulseGenerator = ExponentialShortPulseGenerator()
         self._last_used_forcing: Forcing = None
+        self._noise = None
 
     def make_realization(self) -> Tuple[np.ndarray, np.ndarray]:
         result = np.zeros(len(self._times))
@@ -52,6 +55,9 @@ class PointModel:
         for k in tqdm(range(forcing.total_pulses), position=0, leave=True):
             pulse_parameters = forcing.get_pulse_parameters(k)
             self._add_pulse_to_signal(result, pulse_parameters)
+
+        if self._noise is not None:
+            result += self._noise
 
         self._last_used_forcing = forcing
         return self._times, result
@@ -113,8 +119,13 @@ class PointModel:
         """
         self._pulse_generator = pulse_generator
 
-    def add_noise(self, noise_to_signal_ratio: float, seed: Union[None, int]= None, noise_type: str = "additive"):
-        """ 
+    def add_noise(
+        self,
+        noise_to_signal_ratio: float,
+        seed: Union[None, int] = None,
+        noise_type: str = "additive",
+    ):
+        """
         Adds noise to the realization.
         Parameters
         ----------
@@ -122,12 +133,37 @@ class PointModel:
         seed: None or int, seed for the noise generator
         noise_type: str
             "additive": additive noise
-            "dynamic": dynamic noise
+            "dynamic": dynamic noise (only applicable for constant duration times)
             "both": both additive and dynamic noise
         """
         assert noise_type in {"additive", "dynamic", "both"}
         assert seed is None or isinstance(seed, int)
         assert noise_to_signal_ratio >= 0
+
+        random_number_generator = np.random.RandomState(seed=seed)
+        mean_amplitude = self._forcing_generator.get_forcing(
+            self._times, gamma=self.gamma
+        ).amplitudes.mean()
+        sigma = np.sqrt(noise_to_signal_ratio * self.gamma) * mean_amplitude
+
+        self._noise = np.zeros(len(self._times))
+
+        if noise_type in {"additive", "both"}:
+            self._noise += sigma * random_number_generator.normal(size=len(self._times))
+
+        if noise_type in {"dynamic", "both"}:
+            print(self._times)
+            forcing = self._forcing_generator.get_forcing(self._times, gamma=self.gamma)
+            # use first pulse since all pulses have the same duration
+            pulse_parameters = forcing.get_pulse_parameters(0)
+            kern = self._pulse_generator.get_pulse(
+                np.arange(-self._times[-1] / 2, self._times[-1] / 2, self.dt),
+                pulse_parameters.duration,
+            )
+            dW = random_number_generator.normal(
+                scale=np.sqrt(2 * self.dt), size=len(self._times)
+            )
+            self._noise += sigma * fftconvolve(dW, kern, "same")
 
     def _add_pulse_to_signal(
         self, signal: np.ndarray, pulse_parameters: PulseParameters

--- a/model/point_model.py
+++ b/model/point_model.py
@@ -113,6 +113,22 @@ class PointModel:
         """
         self._pulse_generator = pulse_generator
 
+    def add_noise(self, noise_to_signal_ratio: float, seed: Union[None, int]= None, noise_type: str = "additive"):
+        """ 
+        Adds noise to the realization.
+        Parameters
+        ----------
+        noise_to_signal_ratio: float, defined as X_rms/S_rms where X is noise and S is signal.
+        seed: None or int, seed for the noise generator
+        noise_type: str
+            "additive": additive noise
+            "dynamic": dynamic noise
+            "both": both additive and dynamic noise
+        """
+        assert noise_type in {"additive", "dynamic", "both"}
+        assert seed is None or isinstance(seed, int)
+        assert noise_to_signal_ratio >= 0
+
     def _add_pulse_to_signal(
         self, signal: np.ndarray, pulse_parameters: PulseParameters
     ):


### PR DESCRIPTION
This pull request provides a `add_noise` method to the `PointModel` class. The implementation is analogous to the `gen_noise` function in the old `uit_scripts` repository. 

I am not that happy with the implementation of the dynamic noise since it requires `forcing.get_pulse_parameters()` and `_pulse_generator.get_pulse()`. Encapsulating noise generation is therefore not straight forward. If you @Sosnowsky have a better Idea how to restructure this please let me know.