### PR TITLE
remove matplotlib as a dependency closes #21

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(
         "numpy>=1.15.0",
         "scipy>=1.4.0",
         "tqdm>=4.50.2",
-        "matplotlib>=3.2.0",
     ],
     classifiers=[
         "Intended Audience :: Education",


### PR DESCRIPTION
Remove matplotlib as a dependency to keep MIT License. matplotlib depends on PyQt5, which has a permissive license (AFAIK GPL license). This license would mean that `superposed_pulses` will also be forced to have GPL.