### PR TITLE
License issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(
         "numpy>=1.15.0",
         "scipy>=1.4.0",
         "tqdm>=4.50.2",
-        "matplotlib>=3.2.0",
     ],
     classifiers=[
         "Intended Audience :: Education",


### PR DESCRIPTION
Removed matplotlib as dependency as discussed in #21.

I would also suggest updating the PyPI package with this new update, such that you actually are allowed to use MIT license with the tool. Otherwise, GPL license must be used, which is not ideal (as matplotlib depends on PyQT5 which has GPL license, and thus matplotlib has the same, and therefore your software must as well -> virus license).