### PR TITLE
Gamma to tw

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,10 @@ The simplest case, using defaults: exponential pulse shape, exponentially distri
 import matplotlib.pyplot as plt
 import superposedpulses.point_model as pm
 
-model = pm.PointModel(gamma=0.1, total_duration=100, dt=0.01)
+model = pm.PointModel(waiting_time=10.0, total_duration=100, dt=0.01)
 times, signal = model.make_realization()
 
 plt.plot(times, signal)
 plt.show()
 ```
 Take a look at `superposed-pulses/superposedpulses/example.py` to find out how to change amplitudes, waiting times, duration times and the pulse shape of the process.
-

--- a/superposedpulses/example.py
+++ b/superposedpulses/example.py
@@ -7,7 +7,7 @@ import superposedpulses.pulse_shape as ps
 
 # Simplest case, using defaults: exponential pulse shape, exponentially distributed amplitudes, constant duration times.
 
-model = pm.PointModel(gamma=0.1, total_duration=100, dt=0.01)
+model = pm.PointModel(waiting_time=10.0, total_duration=100, dt=0.01)
 times, signal = model.make_realization()
 
 plt.plot(times, signal)
@@ -15,7 +15,7 @@ plt.show()
 
 # Double exponential shape
 
-model = pm.PointModel(gamma=0.1, total_duration=100, dt=0.01)
+model = pm.PointModel(waiting_time=10.0, total_duration=100, dt=0.01)
 model.set_pulse_shape(ps.StandardPulseGenerator("2-exp", lam=0.35))
 times, signal = model.make_realization()
 
@@ -24,7 +24,7 @@ plt.show()
 
 # Adding noise to the signal
 
-model = pm.PointModel(gamma=0.1, total_duration=100, dt=0.01)
+model = pm.PointModel(waiting_time=10.0, total_duration=100, dt=0.01)
 model.add_noise(noise_to_signal_ratio=0.01, noise_type="additive", seed=None)
 times, signal = model.make_realization()
 
@@ -33,7 +33,7 @@ plt.show()
 
 # Say you want to customise your model a bit: use constant amplitude distribution, and box pulse shapes
 
-model = pm.PointModel(gamma=0.1, total_duration=100, dt=0.01)
+model = pm.PointModel(waiting_time=10.0, total_duration=100, dt=0.01)
 model.set_amplitude_distribution("deg")
 model.set_pulse_shape(ps.BoxShortPulseGenerator())
 
@@ -45,7 +45,7 @@ plt.show()
 # If you want to implement your own distributions, you can do so by setting a custom ForcingGenerator. Say you want half
 # of your pulses to have amplitude 1, and the other half to have amplitude 2.
 
-model = pm.PointModel(gamma=0.1, total_duration=100, dt=0.01)
+model = pm.PointModel(waiting_time=10.0, total_duration=100, dt=0.01)
 my_forcing_gen = frc.StandardForcingGenerator()
 my_forcing_gen.set_amplitude_distribution(
     lambda k: np.random.randint(low=1, high=3, size=k)
@@ -67,8 +67,8 @@ class MyFancyForcingGenerator(frc.ForcingGenerator):
     def __init__(self):
         pass
 
-    def get_forcing(self, times: np.ndarray, gamma: float) -> frc.Forcing:
-        total_pulses = int(max(times) * gamma)
+    def get_forcing(self, times: np.ndarray, waiting_time: float) -> frc.Forcing:
+        total_pulses = int(max(times) / waiting_time)
         arrival_time_indx = np.random.randint(0, len(times), size=total_pulses)
         amplitudes = np.random.default_rng().exponential(scale=1.0, size=total_pulses)
         durations = amplitudes + np.abs(
@@ -88,7 +88,7 @@ class MyFancyForcingGenerator(frc.ForcingGenerator):
         pass
 
 
-model = pm.PointModel(gamma=10, total_duration=1000, dt=0.01)
+model = pm.PointModel(waiting_time=0.1, total_duration=1000, dt=0.01)
 model.set_custom_forcing_generator(MyFancyForcingGenerator())
 
 times, s = model.make_realization()
@@ -104,7 +104,7 @@ plt.hist(forcing.durations)
 plt.show()
 
 # Two point model example
-model = pm.TwoPointModel(gamma=0.1, total_duration=100, dt=0.01)
+model = pm.TwoPointModel(waiting_time=10.0, total_duration=100, dt=0.01)
 model.set_pulse_shape(ps.ExponentialShortPulseGenerator(tolerance=1e-50))
 times, signal_a, signal_b = model.make_realization()
 

--- a/superposedpulses/forcing.py
+++ b/superposedpulses/forcing.py
@@ -53,7 +53,7 @@ class ForcingGenerator(ABC):
     """
 
     @abstractmethod
-    def get_forcing(self, times: np.ndarray, gamma: float) -> Forcing:
+    def get_forcing(self, times: np.ndarray, waiting_time: float) -> Forcing:
         raise NotImplementedError
 
     @abstractmethod
@@ -81,8 +81,8 @@ class StandardForcingGenerator(ForcingGenerator):
         self._amplitude_distribution = None
         self._duration_distribution = None
 
-    def get_forcing(self, times: np.ndarray, gamma: float) -> Forcing:
-        total_pulses = int(max(times) * gamma)
+    def get_forcing(self, times: np.ndarray, waiting_time: float) -> Forcing:
+        total_pulses = int(max(times) / waiting_time)
         arrival_times = np.random.default_rng().uniform(
             low=times[0], high=times[len(times) - 1], size=total_pulses
         )

--- a/superposedpulses/point_model.py
+++ b/superposedpulses/point_model.py
@@ -205,9 +205,10 @@ class PointModel(AbstractModel):
         self._noise_type = noise_type
         self._noise_random_number_generator = np.random.RandomState(seed=seed)
 
-        warnings.warn("Calculation of noise rms "
-                      "(1) assumes average duration time is 1 "
-                      "(2) uses numerical mean amplitude")
+        warnstring = """Calculation of noise rms 
+                        (1) assumes average duration time is 1
+                        (2) uses numerical mean amplitude"""
+        warnings.warn(warnstring)
         mean_amplitude = self._forcing_generator.get_forcing(
             self._times, waiting_time=self.waiting_time
         ).amplitudes.mean()

--- a/superposedpulses/two_point_forcing.py
+++ b/superposedpulses/two_point_forcing.py
@@ -78,8 +78,8 @@ class TwoPointForcingGenerator:
         self._duration_distribution = lambda k: np.ones(k)
         self._delay_distribution = lambda k: np.ones(k)
 
-    def get_forcing(self, times: np.ndarray, gamma: float) -> TwoPointForcing:
-        total_pulses = int(max(times) * gamma)
+    def get_forcing(self, times: np.ndarray, waiting_time: float) -> TwoPointForcing:
+        total_pulses = int(max(times) / waiting_time )
         arrival_times = np.random.default_rng().uniform(
             low=times[0], high=times[len(times) - 1], size=total_pulses
         )


### PR DESCRIPTION
See slack discussion: To separate the point process from the amplitude and duration time distributions, we should specify tw instead of gamma = td/tw. In particular, this allows td to be different than 1 without hidden effects on the intermittency of the process.